### PR TITLE
fixes slicing to use proper indexing

### DIFF
--- a/neuralop/datasets/hmi_zarr_dataset.py
+++ b/neuralop/datasets/hmi_zarr_dataset.py
@@ -1,21 +1,14 @@
+from typing import Optional, List
 import torch
-import zarr
 from datetime import timedelta
 from torch.utils.data import Dataset
-import torchvision
 from pathlib import Path
 from torchvision import transforms
 import numpy as np
 import pandas as pd
-
-from ..utils import UnitGaussianNormalizer
-from .hdf5_dataset import H5pyDataset
-from .zarr_dataset import ZarrDataset
-from .tensor_dataset import TensorDataset
-from .positional_encoding import append_2d_grid_positional_encoding
-from .transforms import Normalizer, PositionalEmbedding, MGPTensorDataset
 import xarray as xr
 
+from .transforms import Normalizer, PositionalEmbedding
 
 
 class HMIZarrDataset(Dataset):
@@ -23,6 +16,8 @@ class HMIZarrDataset(Dataset):
         Parameters:
             filename: str
                 filename pointing to the the zarr arry
+            months: Optional[List[int]]
+                which months to use in this dataset
             resolution: int
                 resolution after subsampling
             center_crop_size: int
@@ -35,24 +30,37 @@ class HMIZarrDataset(Dataset):
                 group name in zarr dataset containing HMI data
             hmi_channel: int
                 index of HMI in zarr group 
-            tstep: int
-                index difference between x and y, actual time difference depends on dataset cadence
+            cadence: timedelta
+                required cadence of the data
+            cadence_epsilon: timedelta
+                tolerance for cadence, 
+                    i.e. only observations with cadence +/- cadence_epsilon are used
     """
-    def __init__(self, filename:str, months=None, resolution:int=4096, center_crop_size:int=2048, 
-                 transform_x=None, transform_y=None, zarr_group:str='hmi',
-                 hmi_channel:int=0, tstep:int=1):
+    def __init__(self, filename:str, 
+                 months: Optional[List[int]] = None, 
+                 resolution: int = 4096, 
+                 center_crop_size: int = 2048, 
+                 transform_x = None, 
+                 transform_y = None, 
+                 zarr_group:str='hmi',
+                 hmi_channel:int=0, 
+                 cadence: timedelta = timedelta(minutes=93), 
+                 cadence_epsilon: timedelta = timedelta(minutes=5)):
         self.zarr_group = zarr_group
         self.hmi_channel = hmi_channel
-        self.tstep = tstep
+        self.cadence_window = (cadence - cadence_epsilon, cadence + cadence_epsilon)
 
         if center_crop_size > resolution:
-            raise RuntimeError(f"Got resolution of {resolution}. Resolution be larger than center_crop_size, found {center_crop_size}.")
+            raise RuntimeError(f"Got resolution of {resolution}."
+                               "Resolution be larger than center_crop_size,"
+                               f"found {center_crop_size}.")
         
         resolution_to_step = {128:32, 256:16, 512:8, 1024:4,2048:2,4096:1}
         try:
             subsample_step = resolution_to_step[resolution]
         except KeyError:
-            raise ValueError(f'Got {resolution=}, expected one of {resolution_to_step.keys()}')
+            raise ValueError(f'Got {resolution=},'
+                             f'expected one of {resolution_to_step.keys()}')
 
         self.subsample_step = subsample_step
         self.filename = str(filename)
@@ -64,25 +72,28 @@ class HMIZarrDataset(Dataset):
 
         self.data = xr.open_zarr(self.filename)
         
+        # select only observations in the requested months
         if months is None:
             months = list(range(1, 13))
-        ti_obs = pd.to_datetime(self.data['t_obs'].data)
-        self.ti_obs = np.array([t for t in ti_obs if t.month in months])
-        self.n_samples = len(self.t_obs)
-        self.tdelta = np.median(np.diff(self.t_obs))*self.tstep
+        self.t_obs =  pd.to_datetime(self.data['t_obs'].data)
+        selected_times = np.array([(i, t) for i, t in 
+                                   enumerate(self.t_obs) if t.month in months])
+        
+        # filter to make sure that each x observation has a corresponding valid y
+        self.x_index = [i for (i, t) in selected_times 
+         if i+1 < len(selected_times) 
+            and (selected_times[i+1][1] - t) > self.cadence_window[0] 
+            and (selected_times[i+1][1] - t) < self.cadence_window[1]]
+        self.y_index = [i+1 for i in self.x_index]
+        self.n_samples = len(self.x_index)
 
-        # if n_samples is not None:
-        #     self.n_samples = n_samples
-        # else:
-        #     data = xr.open_zarr(self.filename)
-        #     self.n_samples = data[self.zarr_group].shape[0] - self.tstep
-        #     del data
-
-    # @property
-    # def data(self):
-    #     if self._data is None:
-    #         self._data = xr.open_zarr(self.filename)
-    #     return self._data
+        # set up the commonly used slices
+        self.crop_slice = np.index_exp[self.crop_start:self.crop_end,
+                                        self.crop_start:self.crop_end]
+        self.sample_slicer = lambda idx: np.index_exp[idx, 
+                                                        self.hmi_channel, 
+                                                        ::self.subsample_step, 
+                                                        ::self.subsample_step]
 
     def __len__(self):
         return self.n_samples
@@ -92,20 +103,18 @@ class HMIZarrDataset(Dataset):
             idx = idx.tolist()
 
         if isinstance(idx, int):
-            assert idx < self.n_samples, f'Trying to access sample {idx} of dataset with {self.n_samples} samples'
+            assert idx < self.n_samples, f'Trying to access sample {idx}'
+            f'of dataset with {self.n_samples} samples'
         else:
             for i in idx:
-                assert i < self.n_samples, f'Trying to access sample {i} of dataset with {self.n_samples} samples'
+                assert i < self.n_samples, f'Trying to access sample {i}'
+                f'of dataset with {self.n_samples} samples'
     
-        x = self.data[self.zarr_group].loc[self.ti_obs[idx], self.hmi_channel, ::self.subsample_step, ::self.subsample_step].load()
-        x = x[self.crop_start:self.crop_end,self.crop_start:self.crop_end]        
-        
-        x = torch.tensor(x, dtype=torch.float32)
+        x = self.data[self.zarr_group][self.sample_slicer(self.x_index[idx])][self.crop_slice].load()
+        x = torch.tensor(x.data, dtype=torch.float32)
 
-        y = self.data[self.zarr_group].loc[self.tf_obs[idx]+timedelta(), self.hmi_channel, ::self.subsample_step, ::self.subsample_step]
-        y = y[self.crop_start:self.crop_end,self.crop_start:self.crop_end]        
-        
-        y = torch.tensor(y, dtype=torch.float32)
+        y = self.data[self.zarr_group][self.sample_slicer(self.y_index[idx])][self.crop_slice].load()
+        y = torch.tensor(y.data, dtype=torch.float32)
 
         if self.transform_x:
             x = self.transform_x(x)
@@ -119,10 +128,10 @@ class HMIZarrDataset(Dataset):
         if torch.is_tensor(idx):
             idx = idx.tolist()
 
-        x = torch.tensor([self.data[self.zarr_group][i, self.hmi_channel, ::self.subsample_step, ::self.subsample_step]
-                          [self.crop_start:self.crop_end,self.crop_start:self.crop_end] for i in idx], dtype=torch.float32)
-        y = torch.tensor([self.data[self.zarr_group][i+self.tstep, self.hmi_channel, ::self.subsample_step, ::self.subsample_step]
-                          [self.crop_start:self.crop_end,self.crop_start:self.crop_end] for i in idx], dtype=torch.float32)
+        x = torch.tensor([self.data[self.zarr_group][self.sample_slicer(self.x_index[i])][self.crop_slice].load().data for i in idx],
+                         dtype=torch.float32)
+        y = torch.tensor([self.data[self.zarr_group][self.sample_slicer(self.y_index[i])][self.crop_slice].load().data for i in idx],
+                         dtype=torch.float32)
 
         if self.transform_x:
             x = self.transform_x(x)
@@ -149,17 +158,22 @@ def load_hmi_zarr(data_path: str, batch_size: int,
         data_path (str): path to HMI zarr
         batch_size (int): batch size for training
         train_resolution (int, optional): Resolution for training data. Defaults to 128.
-        test_resolutions (list, optional): List of resolutions for testing. Defaults to [128, 256, 512, 1024].
-        test_batch_sizes (list, optional): Batch sizes for testing. Defaults to [8, 4, 1].
-        positional_encoding (bool, optional): Whether or not to include positional encoding. Defaults to True.
+        test_resolutions (list, optional): List of resolutions for testing. 
+            Defaults to [128, 256, 512, 1024].
+        test_batch_sizes (list, optional): Batch sizes for testing.
+            Defaults to [8, 4, 1].
+        positional_encoding (bool, optional): Whether or not to 
+            include positional encoding. Defaults to True.
         grid_boundaries (list, optional): Defaults to [[0,1],[0,1]].
         encode_input (bool, optional): _description_. Defaults to True.
         encode_output (bool, optional): _description_. Defaults to True.
         num_workers (int, optional): _description_. Defaults to 0.
         pin_memory (bool, optional): _description_. Defaults to True.
         persistent_workers (bool, optional): _description_. Defaults to False.
-        center_crop_size (int, optional): Size in pixels to crop from center of full image. Defaults to 2048.
-        hmi_std (int, optional): Standard deviation parameter for normalizing HMI. Defaults to 300G.
+        center_crop_size (int, optional): Size in pixels to 
+            crop from center of full image. Defaults to 2048.
+        hmi_std (int, optional): Standard deviation parameter 
+            for normalizing HMI. Defaults to 300G.
 
     Returns:
         train_loader
@@ -213,7 +227,8 @@ def load_hmi_zarr(data_path: str, batch_size: int,
             transform_y = Normalizer(y_mean, y_std)
 
         test_db = HMIZarrDataset(data_path, resolution=res, 
-                              transform_x=transforms.Compose(transform_x), transform_y=transform_y)
+                              transform_x=transforms.Compose(transform_x), 
+                              transform_y=transform_y)
     
         test_loaders[res] = torch.utils.data.DataLoader(test_db, 
                                                         batch_size=test_batch_size,

--- a/neuralop/datasets/hmi_zarr_dataset.py
+++ b/neuralop/datasets/hmi_zarr_dataset.py
@@ -44,7 +44,7 @@ class HMIZarrDataset(Dataset):
                  transform_y = None, 
                  zarr_group:str='hmi',
                  hmi_channel:int=0, 
-                 cadence: timedelta = timedelta(minutes=93), 
+                 cadence: timedelta = timedelta(minutes=96), 
                  cadence_epsilon: timedelta = timedelta(minutes=5)):
         self.zarr_group = zarr_group
         self.hmi_channel = hmi_channel
@@ -80,11 +80,13 @@ class HMIZarrDataset(Dataset):
                                    enumerate(self.t_obs) if t.month in months])
         
         # filter to make sure that each x observation has a corresponding valid y
+        t_diff = np.median(np.diff(self.t_obs))
+        step = int(np.round(np.timedelta64(cadence)/t_diff))
         self.x_index = [i for (i, t) in selected_times 
-         if i+1 < len(selected_times) 
-            and (selected_times[i+1][1] - t) > self.cadence_window[0] 
-            and (selected_times[i+1][1] - t) < self.cadence_window[1]]
-        self.y_index = [i+1 for i in self.x_index]
+         if i+step < len(selected_times) 
+            and (selected_times[i+step][1] - t) > self.cadence_window[0] 
+            and (selected_times[i+step][1] - t) < self.cadence_window[1]]
+        self.y_index = [i+step for i in self.x_index]
         self.n_samples = len(self.x_index)
 
         # set up the commonly used slices

--- a/neuralop/tests/test_hmi_zarr_dataset.py
+++ b/neuralop/tests/test_hmi_zarr_dataset.py
@@ -1,17 +1,30 @@
-import pytest
+from datetime import timedelta
+
 from neuralop.datasets.hmi_zarr_dataset import HMIZarrDataset
 
-def test_select_times():
+def test_select_months():
     filename = '/d0/magnetograms/hmi/preprocessed/hmi_stacks_2021_2022_96m_full.zarr'
-    dataset = HMIZarrDataset(filename,months=[1])
-    assert all([t.month==1 for t in dataset.t_obs])
+    dataset = HMIZarrDataset(filename, months=[1])
+    assert all([dataset.t_obs[i].month==1 for i in dataset.x_index])
+    assert all([dataset.t_obs[i].month==1 for i in dataset.y_index])
+    
+def test_cadence_filtering_works():
+    filename = '/d0/magnetograms/hmi/preprocessed/hmi_stacks_2021_2022_96m_full.zarr'
+    dataset = HMIZarrDataset(filename, months=[1])
+    for i in range(len(dataset)):
+        x_time = dataset.t_obs[dataset.x_index[i]]
+        y_time = dataset.t_obs[dataset.y_index[i]]
+        assert (y_time - x_time) > timedelta(minutes=91)
+        assert (y_time - x_time) < timedelta(minutes=101)
 
 def test_get_item():
-    print("testing item shape")
     filename = '/d0/magnetograms/hmi/preprocessed/hmi_stacks_2021_2022_96m_full.zarr'
     dataset = HMIZarrDataset(filename)
     data = dataset[0]
     assert data['x'].shape == (2048, 2048)
     assert data['y'].shape == (2048, 2048)
-
+    
+    data = dataset[100]
+    assert data['x'].shape == (2048, 2048)
+    assert data['y'].shape == (2048, 2048)
 

--- a/neuralop/tests/test_hmi_zarr_dataset.py
+++ b/neuralop/tests/test_hmi_zarr_dataset.py
@@ -8,7 +8,7 @@ def test_select_months():
     assert all([dataset.t_obs[i].month==1 for i in dataset.x_index])
     assert all([dataset.t_obs[i].month==1 for i in dataset.y_index])
     
-def test_cadence_filtering_works():
+def test_cadence_filtering_default():
     filename = '/d0/magnetograms/hmi/preprocessed/hmi_stacks_2021_2022_96m_full.zarr'
     dataset = HMIZarrDataset(filename, months=[1])
     for i in range(len(dataset)):
@@ -16,6 +16,16 @@ def test_cadence_filtering_works():
         y_time = dataset.t_obs[dataset.y_index[i]]
         assert (y_time - x_time) > timedelta(minutes=91)
         assert (y_time - x_time) < timedelta(minutes=101)
+        
+        
+def test_cadence_filtering_192_minutes():
+    filename = '/d0/magnetograms/hmi/preprocessed/hmi_stacks_2021_2022_96m_full.zarr'
+    dataset = HMIZarrDataset(filename, months=[1], cadence=timedelta(minutes=192))
+    for i in range(len(dataset)):
+        x_time = dataset.t_obs[dataset.x_index[i]]
+        y_time = dataset.t_obs[dataset.y_index[i]]
+        assert (y_time - x_time) > timedelta(minutes=187)
+        assert (y_time - x_time) < timedelta(minutes=197)
 
 def test_get_item():
     filename = '/d0/magnetograms/hmi/preprocessed/hmi_stacks_2021_2022_96m_full.zarr'


### PR DESCRIPTION
We talked a lot about proper indexing on August 16th. I implemented an indexing scheme based x and y images having to be withing a cadence +/- cadence_epsilon. The epsilon is included because we know that not all observations will be exactly 96 minutes apart; there might be some seconds different. For example, I require as a default that all y observations be within 91 and 101 minutes of the x observations. This is controlled by `self.x_index` and `self.y_index`. Thus, when you want `dataset[42]` it really looks up in the `self.x_index[42]` and `self.y_index[42]` to find the raw index in the original zarr and returns that. It's all implemented in the `__getitem__` method so the user should never have to worry much about it hopefully. 

I also moved our slicing into attributes using `np.index_exp` so that we don't repeat all the slices in multiple methods. We can just change them in one spot. Hooray! 

I updated/added tests to convince myself everything was working. 

Feel free to offer improvements on this scheme. 